### PR TITLE
Adjust sample to configcat-vue improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "configcat-vue-sample",
       "version": "0.0.0",
       "dependencies": {
-        "configcat-js": "^8.0.2",
         "configcat-vue": "^1.2.0",
         "vue": "^3.2.45"
       },
@@ -495,23 +494,6 @@
       "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.45.tgz",
       "integrity": "sha512-Ewzq5Yhimg7pSztDV+RH1UDKBzmtqieXQlpTVm2AwraoRL/Rks96mvd8Vgi7Lj+h+TH8dv7mXD3FRZR3TUvbSg=="
     },
-    "node_modules/configcat-common": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/configcat-common/-/configcat-common-8.0.2.tgz",
-      "integrity": "sha512-/Z2FRTaomEzp7hwhh3P98u8RVCiD/yNZVo9YYKfSCxAPY7Nljq4ZGPhRD75pnO3d5YZBrnKhElzlKgZYnV9XAw==",
-      "dependencies": {
-        "tslib": "^2.4.1"
-      }
-    },
-    "node_modules/configcat-js": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/configcat-js/-/configcat-js-8.0.2.tgz",
-      "integrity": "sha512-g9FGdlyQ/f1OFfHoxZ96FpKFu71S6X9XTZa1O6W4nshG3fLtf1QwRYfY0YSyAxtW7go2uqAtwf3FVo4xhgwedA==",
-      "dependencies": {
-        "configcat-common": "^8.0.2",
-        "tslib": "^2.4.1"
-      }
-    },
     "node_modules/configcat-vue": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/configcat-vue/-/configcat-vue-1.2.0.tgz",
@@ -727,11 +709,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/tslib": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
     },
     "node_modules/vite": {
       "version": "4.0.0",
@@ -1061,23 +1038,6 @@
       "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.45.tgz",
       "integrity": "sha512-Ewzq5Yhimg7pSztDV+RH1UDKBzmtqieXQlpTVm2AwraoRL/Rks96mvd8Vgi7Lj+h+TH8dv7mXD3FRZR3TUvbSg=="
     },
-    "configcat-common": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/configcat-common/-/configcat-common-8.0.2.tgz",
-      "integrity": "sha512-/Z2FRTaomEzp7hwhh3P98u8RVCiD/yNZVo9YYKfSCxAPY7Nljq4ZGPhRD75pnO3d5YZBrnKhElzlKgZYnV9XAw==",
-      "requires": {
-        "tslib": "^2.4.1"
-      }
-    },
-    "configcat-js": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/configcat-js/-/configcat-js-8.0.2.tgz",
-      "integrity": "sha512-g9FGdlyQ/f1OFfHoxZ96FpKFu71S6X9XTZa1O6W4nshG3fLtf1QwRYfY0YSyAxtW7go2uqAtwf3FVo4xhgwedA==",
-      "requires": {
-        "configcat-common": "^8.0.2",
-        "tslib": "^2.4.1"
-      }
-    },
     "configcat-vue": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/configcat-vue/-/configcat-vue-1.2.0.tgz",
@@ -1228,11 +1188,6 @@
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true
-    },
-    "tslib": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
     },
     "vite": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "configcat-js": "^8.0.2",
     "configcat-vue": "^1.2.0",
     "vue": "^3.2.45"
   },

--- a/src/main.js
+++ b/src/main.js
@@ -2,14 +2,13 @@ import { createApp } from 'vue';
 import App from './App.vue';
 import '../assets/main.css';
 
-// import { ConfigCatPlugin } from "configcat-vue";
+import { ConfigCatPlugin } from "configcat-vue";
 
-// If you need to use a logger
-// Add ConsoleLogger and LogLevel to your import
+// If you need to customize ConfigCat-related logging, import createConsoleLogger and LogLevel as well.
 
-import { ConfigCatPlugin, createConsoleLogger, LogLevel } from "configcat-vue";
+import { createConsoleLogger, LogLevel } from "configcat-vue";
 
-const logger = createConsoleLogger(LogLevel.Info); // Create a binding for the logger and specify the log level. 
+const logger = createConsoleLogger(LogLevel.Info); // Create a binding for the logger and specify the log level.
 
 // documentation: https://configcat.com/docs/sdk-reference/js/#logging
 


### PR DESCRIPTION
Counterpart of https://github.com/codedbychavez/configcat-vue/pull/11

Apart from the necessary adjustments to the `configcat-vue` improvements, also proposes some corrections.

Note: before merging this, we need to release `configcat-vue` first and update the `configcat-vue` version to the latest.